### PR TITLE
ext-intl no longer needed?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,8 +101,7 @@
         ]
     },
     "require": {
-        "php": ">= 8.2",
-        "ext-intl": "*"
+        "php": ">= 8.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^1",


### PR DESCRIPTION
This seems to be redundant and is causing issues elsewhere...